### PR TITLE
fixing speedmod title changing location bug

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -328,7 +328,8 @@ ContainerOffCommand=smooth,0.5;x,SCREEN_WIDTH
 [OptionRow]
 TitleGainFocusCommand=diffuse,color("#FFFFFF");
 TitleLoseFocusCommand=diffuse,color("#666666");
-TitleOnCommand=shadowlength,0;wrapwidthpixels,SCREEN_WIDTH*0.2;zoom,0.75;addx,-13;horizalign,left;
+TitleX=SCREEN_CENTER_X-222-39
+TitleOnCommand=shadowlength,0;wrapwidthpixels,SCREEN_WIDTH*0.2;zoom,0.75;horizalign,left;
 ColorSelected=color("#FFFFFF")
 ColorNotSelected=color("0.5,0.5,0.5,1")
 ColorDisabled=color("0.25,0.25,0.25,1")


### PR DESCRIPTION
for some reason when you change the speedmod it removes the addx,-13, by adding it to TitleX instead fixes it
